### PR TITLE
Update model components for tags

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,12 +2,16 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.UniqueTagList;
 
 /**
  * Wraps all data at the address-book level
@@ -16,6 +20,7 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
+    private final UniqueTagList tags;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -26,6 +31,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
+        tags = new UniqueTagList();
     }
 
     public AddressBook() {}
@@ -70,9 +76,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
+     * Also, makes sure that there are only one tag object per unique tag.
      */
     public void addPerson(Person p) {
-        persons.add(p);
+        requireNonNull(p);
+        Set<Tag> managedTags = new HashSet<>();
+        for (Tag tag : p.getTags()) {
+            managedTags.add(tags.createOrGetTag(tag));
+        }
+        Person updatedPerson = new Person(p.getName(), p.getPhone(), p.getParentPhone(), p.getEmail(), managedTags);
+        persons.add(updatedPerson);
     }
 
     /**
@@ -106,6 +119,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Person> getPersonList() {
         return persons.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Tag> getTagList() {
+        return tags.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 
 /**
  * Unmodifiable view of an address book
@@ -14,4 +15,9 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Person> getPersonList();
 
+    /**
+     * Returns an unmodifiable view of the tag list.
+     * This list will not contain any duplicate tags.
+     */
+    ObservableList<Tag> getTagList();
 }

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -1,0 +1,88 @@
+package seedu.address.model.tag;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * Represents a list of unique tags that does not allow duplicate tags.
+ * Tags are considered duplicates if they are equal according to their {@code equals()} method.
+ *
+ * <p>The class provides functionality to add tags if they don't already exist
+ * and retrieve an unmodifiable view of the internal list of tags. This ensures
+ * that the integrity of the list is maintained while allowing controlled access.
+ *
+ * <p>Use cases:
+ * - To manage a central, unique list of tags that can be associated with other entities.
+ * - To prevent duplicate tags from being created in the system.
+ *
+ * <p>Thread Safety:
+ * This class is not thread-safe as it uses {@code ObservableList}, which
+ * is not inherently synchronized.
+ */
+public class UniqueTagList implements Iterable<Tag> {
+    private final ObservableList<Tag> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Tag> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Ensures a tag exists in the list. If it doesn't, adds it to the list.
+     * Returns the existing tag if found, or the newly added tag.
+     *
+     * @param toAdd The tag to be added or retrieved. Must not be null.
+     * @return The existing tag if found, otherwise the newly added tag.
+     */
+    public Tag createOrGetTag(Tag toAdd) {
+        requireNonNull(toAdd);
+        for (Tag tag : internalList) {
+            if (tag.equals(toAdd)) {
+                return tag;
+            }
+        }
+        internalList.add(toAdd);
+        return toAdd;
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     * This prevents external modification of the internal list.
+     *
+     * @return An unmodifiable view of the list of tags.
+     */
+    public ObservableList<Tag> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Tag> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UniqueTagList)) {
+            return false;
+        }
+
+        UniqueTagList otherUniqueTagList = (UniqueTagList) other;
+        return internalList.equals(otherUniqueTagList.internalList);
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return internalList.toString();
+    }
+}


### PR DESCRIPTION
Model now allows `AddressBook` to only require one `Tag` object per unique tag, instead of each `Person` needing their own `Tag` object.